### PR TITLE
Convert AlertPage and service worker to TypeScript

### DIFF
--- a/src/pages/AlertPage.tsx
+++ b/src/pages/AlertPage.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable jsx-a11y/href-no-hash */
 
+import React from 'react';
 import Page from 'components/Page';
 import Typography from 'components/Typography';
-import React from 'react';
 import {
   Alert,
   Card,
@@ -13,7 +13,7 @@ import {
   UncontrolledAlert,
 } from 'reactstrap';
 
-const AlertPage = () => {
+const AlertPage: React.FC = () => {
   return (
     <Page title="Alerts" breadcrumbs={[{ name: 'alerts', active: true }]}>
       <Row>

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -18,7 +18,7 @@ const isLocalhost = Boolean(
     )
 );
 
-export default function register() {
+export default function register(): void {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);
@@ -43,12 +43,15 @@ export default function register() {
   }
 }
 
-function registerValidSW(swUrl) {
+function registerValidSW(swUrl: string): void {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration: ServiceWorkerRegistration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
+        if (!installingWorker) {
+          return;
+        }
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
             if (navigator.serviceWorker.controller) {
@@ -72,7 +75,7 @@ function registerValidSW(swUrl) {
     });
 }
 
-function checkValidServiceWorker(swUrl) {
+function checkValidServiceWorker(swUrl: string): void {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
@@ -82,7 +85,7 @@ function checkValidServiceWorker(swUrl) {
         response.headers.get('content-type').indexOf('javascript') === -1
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -99,9 +102,9 @@ function checkValidServiceWorker(swUrl) {
     });
 }
 
-export function unregister() {
+export function unregister(): void {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
+    navigator.serviceWorker.ready.then((registration: ServiceWorkerRegistration) => {
       registration.unregister();
     });
   }


### PR DESCRIPTION
## Summary
- migrate AlertPage component to TypeScript React.FC
- convert service worker registration to TypeScript with typed parameters

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7484b9a60832e87c825f7d3895c63